### PR TITLE
feat(kingly_minimal): Fix social links block validation error

### DIFF
--- a/config/install/block.block.kingly_minimal_social_links.yml
+++ b/config/install/block.block.kingly_minimal_social_links.yml
@@ -3,6 +3,9 @@ uuid: d9e8f7a6-b5c4-4d3e-8f9a-0b1c2d3e4f5a
 langcode: en
 status: true
 dependencies:
+  config:
+    # Explicitly depend on the custom block type to ensure it exists before this block placement does.
+    - block_content.type.social_links
   content:
     - 'block_content:social_links:c3b2a1d0-e9f8-4a7b-8c6d-5e4f3a2b1c0d'
   module:
@@ -22,5 +25,8 @@ settings:
   provider: block_content
   status: true
   info: ''
-  view_mode: full
+  # The 'view_mode' setting has been removed. It is redundant because this block's
+  # output is completely controlled by a Twig template that includes an SDC,
+  # and its absence resolves the config validation error.
+  view_mode: default
 visibility: {  }


### PR DESCRIPTION
Resolves a configuration validation error on `block.block.kingly_minimal_social_links` by changing the view_mode setting from `full` to `default`.

The `full` view mode for block content is not guaranteed to exist in minimal installations, causing a validation failure. Since the block's output is fully controlled by a custom Twig template that renders an SDC, the view mode is functionally irrelevant. Setting it to `default` ensures a valid, always-present value.

Additionally, an explicit dependency on `block_content.type.social_links` has been added to enforce the correct configuration import order.