### PR TITLE
feat(block): Fix social links block plugin discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,5 +3,10 @@
   "type": "drupal-theme",
   "description": "A minimal, modern base theme with a Vite-powered SCSS toolchain.",
   "license": "GPL-2.0-or-later",
+  "autoload": {
+    "psr-4": {
+      "Drupal\\kingly_minimal\\": "src/"
+    }
+  },
   "require": {}
 }


### PR DESCRIPTION
Resolves the "broken or missing block" error for the "Follow Us" social block by implementing PSR-4 autoloading.

- Adds a PSR-4 autoload definition to `composer.json` for the `Drupal\kingly_minimal` namespace, mapping it to the `src/` directory. This aligns the theme with modern Drupal development standards.
- Moves the `SocialLinksBlock.php` plugin into the correct `src/Plugin/Block/` directory, making it discoverable by Drupal's plugin system.

This change allows the block to be correctly instantiated, which in turn renders the `social-links` SDC in the footer.