### PR TITLE
feat(components): Add Image and Text SDCs

### DIFF
--- a/components/image/image.component.yml
+++ b/components/image/image.component.yml
@@ -1,0 +1,57 @@
+# components/image/image.component.yml
+name: 'Image'
+status: stable
+description: 'Renders a responsive image, optionally wrapped in a link and with a caption.'
+
+props:
+  type: object
+  properties:
+    # The responsive image style from Drupal. If provided, it will be used to
+    # render a <picture> element.
+    responsive_image_style:
+      type: string
+      title: 'Responsive Image Style'
+      description: 'The machine name of a Drupal responsive image style to use.'
+      default: ''
+    # Fallback src, used if no responsive_image_style is provided.
+    src:
+      type: string
+      title: 'Image Source'
+      description: 'The URL for the image. Required if responsive_image_style is not set.'
+      default: ''
+    # Alt text is critical for accessibility.
+    alt:
+      type: string
+      title: 'Alt Text'
+      description: 'The alternative text for the image.'
+      required: true
+    # Width and height help prevent Cumulative Layout Shift (CLS).
+    width:
+      type: [string, number]
+      title: 'Width'
+      description: 'The native width of the image.'
+    height:
+      type: [string, number]
+      title: 'Height'
+      description: 'The native height of the image.'
+    # An optional caption. If provided, the component uses <figure>.
+    caption:
+      type: string
+      title: 'Caption'
+      description: 'An optional caption for the image. If provided, the output will be wrapped in a <figure> element.'
+    # An optional URL to make the image a link.
+    url:
+      type: string
+      title: 'URL'
+      description: 'An optional URL to wrap the image in a link.'
+    # A Drupal attributes object for the wrapper element.
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the root element.'
+
+# Define the component's CSS assets.
+library:
+  css:
+    component:
+      image.css: {}

--- a/components/image/image.scss
+++ b/components/image/image.scss
@@ -1,0 +1,30 @@
+// components/image/image.scss
+
+// -----------------------------------------------------------------------------
+// Image Component Styles
+// -----------------------------------------------------------------------------
+
+[data-component-id='kingly_minimal:image'] {
+  // The root element is a <figure> or <div>.
+  // We use `max-width: 100%` to ensure it doesn't overflow its container.
+  max-width: 100%;
+  // `width: fit-content` makes the figure only as wide as the image it contains.
+  width: fit-content;
+  margin: 0; // Reset browser default margins on <figure>.
+
+  // The <img> or <picture> element within the component.
+  // It is already responsive due to the `max-width: 100%` in _reset.scss.
+  // We add a border-radius for a consistent look.
+  img {
+    border-radius: var(--border-radius);
+    display: block; // Ensures no extra space is added below the image.
+  }
+
+  // Styles for the optional caption.
+  .image-component__caption {
+    padding-top: var(--spacing-sm);
+    font-size: var(--font-size-sm);
+    color: var(--color-text);
+    text-align: center;
+  }
+}

--- a/components/image/image.twig
+++ b/components/image/image.twig
@@ -1,0 +1,62 @@
+{#
+/**
+ * @file
+ * Component template for a responsive image.
+ *
+ * This component renders an image, handling different use cases:
+ * - If a caption is provided, it uses a semantic <figure> and <figcaption>.
+ * - If a URL is provided, the image becomes a link.
+ * - If a responsive_image_style is provided, it renders a <picture> element
+ *   for optimal performance. (Note: This assumes a Twig extension like
+ *   Twig Tweak is installed to provide a drupal_image() function).
+ * - Otherwise, it renders a standard <img> tag.
+ *
+ * @see kingly_minimal/components/image/image.component.yml
+ *
+ * @props
+ * - responsive_image_style: (Optional) Machine name of a responsive image style.
+ * - src: The URI or URL of the image.
+ * - alt: The required alt text for accessibility.
+ * - width: (Optional) The native width of the image.
+ * - height: (Optional) The native height of the image.
+ * - caption: (Optional) A caption for the image.
+ * - url: (Optional) A URL to make the image a link.
+ * - attributes: A Drupal attributes object for the wrapper.
+ */
+#}
+{% set has_caption = caption is not empty %}
+{# Use a <figure> for semantic correctness if a caption exists. #}
+{% set root_tag = has_caption ? 'figure' : 'div' %}
+
+<{{ root_tag }}{{ attributes.addClass('image-component') }}>
+{% if url %}
+<a href="{{ url }}" class="image-component__link">
+  {% endif %}
+
+  {#
+  Render a responsive <picture> element if a style is specified.
+  This provides the best practice for responsive images in Drupal.
+  NOTE: This requires a helper function, typically from a module like Twig Tweak.
+  Without it, you would need to pass a pre-rendered image to this component.
+  #}
+  {% if responsive_image_style %}
+    {{ drupal_image(src, responsive_image_style, {alt: alt, width: width, height: height}) }}
+  {% else %}
+    {# Fallback to a standard <img> tag if no responsive style is given. #}
+    <img
+      src="{{ src }}"
+      alt="{{ alt }}"
+      {{ width ? 'width="' ~ width ~ '"' }}
+      {{ height ? 'height="' ~ height ~ '"' }}
+      loading="lazy"
+    >
+  {% endif %}
+
+  {% if url %}
+</a>
+{% endif %}
+
+  {% if has_caption %}
+    <figcaption class="image-component__caption">{{ caption }}</figcaption>
+  {% endif %}
+</{{ root_tag }}>

--- a/components/text/text.component.yml
+++ b/components/text/text.component.yml
@@ -1,0 +1,31 @@
+# components/text/text.component.yml
+name: 'Text'
+status: stable
+description: 'A component for rendering long-form "prose" or "WYSIWYG" rich text content with consistent, readable styling.'
+
+props:
+  type: object
+  properties:
+    # The main content to be rendered. This should be a string containing HTML.
+    content:
+      type: [string, object] # Can be a string or a render array.
+      title: 'Content'
+      description: 'The rich text or HTML content to be styled.'
+      required: true
+    # HTML tag for the wrapper element.
+    element:
+      type: string
+      title: 'Wrapper Element'
+      description: 'The HTML tag for the root element.'
+      default: 'div'
+    # Drupal attributes object for the wrapper.
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the root element.'
+
+# Define the component's CSS assets.
+library:
+  css:
+    component:
+      text.css: {}

--- a/components/text/text.scss
+++ b/components/text/text.scss
@@ -1,0 +1,108 @@
+// components/text/text.scss
+
+// -----------------------------------------------------------------------------
+// Text ("Prose") Component Styles
+//
+// This file styles generic HTML elements within a `.prose` container, making it
+// perfect for WYSIWYG editor output or long-form content from a text field.
+// We use the `> * + *` (lobotomized owl) selector for consistent vertical
+// spacing between elements.
+// -----------------------------------------------------------------------------
+
+[data-component-id='kingly_minimal:text'].prose {
+  // --- Vertical Spacing ---
+  // Apply a consistent top margin to every direct child element that follows
+  // another element. This prevents double margins.
+  > * + * {
+    margin-block-start: 1.25em;
+  }
+
+  // --- Typography & Elements ---
+  p,
+  ul,
+  ol,
+  dl,
+  blockquote {
+    line-height: var(--line-height-base);
+  }
+
+  // --- Headings ---
+  // Style all heading levels within the prose block.
+  > h1,
+  > h2,
+  > h3,
+  > h4,
+  > h5,
+  > h6 {
+    font-family: var(--font-family-heading);
+    line-height: var(--line-height-heading);
+    font-weight: 700;
+  }
+
+  > h1 { font-size: 2.25rem; }
+  > h2 { font-size: 1.75rem; }
+  > h3 { font-size: 1.5rem; }
+  > h4 { font-size: 1.25rem; }
+  > h5 { font-size: 1.1rem; }
+  > h6 { font-size: 1rem; }
+
+  // --- Lists ---
+  // Apply padding only to the main lists, not nested ones, to avoid
+  // excessive indentation.
+  > ul,
+  > ol {
+    padding-inline-start: 1.5rem;
+  }
+
+  // --- Blockquotes ---
+  > blockquote {
+    padding-inline-start: var(--spacing-md);
+    border-inline-start: 3px solid var(--color-border);
+    font-style: italic;
+    color: color-mix(in srgb, var(--color-text), #fff 20%);
+
+    p {
+      // Don't add extra margins for paragraphs inside a blockquote.
+      margin-block-start: 0;
+    }
+  }
+
+  // --- Links ---
+  a {
+    // A slightly different style for links within prose for better readability.
+    text-decoration: underline;
+
+    &:hover {
+      color: var(--color-primary-hover);
+    }
+  }
+
+  // --- Code Blocks & Horizontal Rules ---
+  pre,
+  code {
+    font-family: monospace;
+    background-color: var(--color-light-gray);
+    border-radius: var(--border-radius);
+    padding: var(--spacing-xs) var(--spacing-sm);
+  }
+
+  pre {
+    padding: var(--spacing-md);
+    overflow-x: auto;
+  }
+
+  hr {
+    border: none;
+    border-top: var(--border-width) solid var(--color-border);
+  }
+
+  // --- Remove Spacing on First/Last Child ---
+  // Ensures the component doesn't have extra space at its very top or bottom.
+  > *:first-child {
+    margin-block-start: 0;
+  }
+
+  > *:last-child {
+    margin-block-end: 0;
+  }
+}

--- a/components/text/text.twig
+++ b/components/text/text.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Component template for styled "prose" text.
+ *
+ * This component simply wraps the provided HTML content in a container element.
+ * The `prose` class, applied via attributes, is the hook for the component's
+ * SCSS to apply styling to all the standard HTML elements within.
+ *
+ * @see kingly_minimal/components/text/text.component.yml
+ *
+ * @props
+ * - content: The rich text or HTML content to be styled.
+ * - element: (Optional) The HTML tag for the root element, defaults to 'div'.
+ * - attributes: A Drupal attributes object for the root element.
+ */
+#}
+<{{ element|default('div') }}{{ attributes.addClass('prose') }}>
+{{- content -}}
+</{{ element|default('div') }}>


### PR DESCRIPTION
Adds two new foundational Single Directory Components for content rendering.

The `Image` component provides a versatile and semantic way to display responsive images. It supports optional captions (using `<figure>`), links, and integrates with Drupal's responsive image styles.

The `Text` component is a "prose" wrapper designed to apply consistent and readable styling to long-form rich text content, such as that from a WYSIWYG editor. It uses modern CSS techniques for robust vertical spacing and scoped styling.