### PR TITLE
refactor(components): Integrate Image and Text components into theme

### DIFF
--- a/components/footer-company-info/footer-company-info.twig
+++ b/components/footer-company-info/footer-company-info.twig
@@ -3,6 +3,10 @@
  * @file
  * Component template for the footer company info section.
  *
+ * This component has been refactored to use the `Text` component for its
+ * description. This allows the description to contain simple HTML (like links
+ * or bold text) and have it styled consistently by the `prose` styles.
+ *
  * @see kingly_minimal/components/footer-company-info/footer-company-info.component.yml
  *
  * @props
@@ -16,8 +20,14 @@
     <h3 class="footer-company-info__name">{{ company_name }}</h3>
   {% endif %}
   {% if description %}
-    <p class="footer-company-info__description">
-      {{ description }}
-    </p>
+    {#
+    Delegate rendering of the description to the Text component.
+    This ensures that if the description contains any simple HTML,
+    it will be styled correctly by the .prose class.
+    #}
+    {{ include('kingly_minimal:text', {
+      content: description,
+      attributes: { class: ['footer-company-info__description'] }
+    }, with_context=false) }}
   {% endif %}
 </div>

--- a/components/image/image.component.yml
+++ b/components/image/image.component.yml
@@ -6,6 +6,11 @@ description: 'Renders a responsive image, optionally wrapped in a link and with 
 props:
   type: object
   properties:
+    # This new prop allows us to pass in a pre-rendered Drupal image.
+    render_array:
+      type: object
+      title: 'Render Array'
+      description: 'A pre-rendered Drupal image or picture element. If provided, this will be used instead of constructing an image from src/alt.'
     # The responsive image style from Drupal. If provided, it will be used to
     # render a <picture> element.
     responsive_image_style:
@@ -23,8 +28,7 @@ props:
     alt:
       type: string
       title: 'Alt Text'
-      description: 'The alternative text for the image.'
-      required: true
+      description: 'The alternative text for the image. Not required if passing a pre-rendered `render_array`.'
     # Width and height help prevent Cumulative Layout Shift (CLS).
     width:
       type: [string, number]

--- a/components/image/image.twig
+++ b/components/image/image.twig
@@ -6,14 +6,15 @@
  * This component renders an image, handling different use cases:
  * - If a caption is provided, it uses a semantic <figure> and <figcaption>.
  * - If a URL is provided, the image becomes a link.
- * - If a responsive_image_style is provided, it renders a <picture> element
- *   for optimal performance. (Note: This assumes a Twig extension like
- *   Twig Tweak is installed to provide a drupal_image() function).
+ * - If a `render_array` is provided, it prints it directly. This is the
+ *   preferred way to handle pre-rendered Drupal images.
+ * - If a `responsive_image_style` is provided, it renders a <picture> element.
  * - Otherwise, it renders a standard <img> tag.
  *
  * @see kingly_minimal/components/image/image.component.yml
  *
  * @props
+ * - render_array: (Optional) A pre-rendered Drupal image array.
  * - responsive_image_style: (Optional) Machine name of a responsive image style.
  * - src: The URI or URL of the image.
  * - alt: The required alt text for accessibility.
@@ -34,15 +35,19 @@
   {% endif %}
 
   {#
-  Render a responsive <picture> element if a style is specified.
-  This provides the best practice for responsive images in Drupal.
-  NOTE: This requires a helper function, typically from a module like Twig Tweak.
-  Without it, you would need to pass a pre-rendered image to this component.
+  Priority 1: If a pre-rendered array is passed, print it directly.
+  This is the most Drupal-native way to handle things like `author_picture`.
   #}
-  {% if responsive_image_style %}
+  {% if render_array %}
+    {{ render_array }}
+  {% elseif responsive_image_style %}
+    {#
+    Priority 2: Render a responsive <picture> element if a style is specified.
+    NOTE: This requires a helper function like `drupal_image()` from Twig Tweak.
+    #}
     {{ drupal_image(src, responsive_image_style, {alt: alt, width: width, height: height}) }}
   {% else %}
-    {# Fallback to a standard <img> tag if no responsive style is given. #}
+    {# Priority 3: Fallback to a standard <img> tag. #}
     <img
       src="{{ src }}"
       alt="{{ alt }}"

--- a/components/node-teaser/node-teaser.twig
+++ b/components/node-teaser/node-teaser.twig
@@ -3,8 +3,9 @@
  * @file
  * Component template for a node teaser.
  *
- * This component structures the content for a node teaser, including the title,
- * metadata, and content summary. It's designed to be used in lists of content.
+ * This component structures the content for a node teaser. It now delegates
+ * rendering of the author picture and content body to the `image` and `text`
+ * components respectively for better consistency and maintainability.
  *
  * @see kingly_minimal/components/node-teaser/node-teaser.component.yml
  *
@@ -27,16 +28,29 @@
   {# Render the "Submitted by" metadata if it exists. #}
   {% if submitted %}
     <footer class="node__meta">
-      {{ author_picture }}
+      {#
+      Delegate rendering of the author's picture to our Image component.
+      We pass the pre-rendered `author_picture` array directly.
+      #}
+      {{ include('kingly_minimal:image', {
+        render_array: author_picture,
+        attributes: { class: ['user-picture'] }
+      }, with_context=false) }}
+
       <div class="node__submitted">
         {{ submitted }}
       </div>
     </footer>
   {% endif %}
 
-  {# Render the main teaser content (e.g., summary). #}
+  {#
+  Render the main teaser content using our Text component.
+  This ensures consistent WYSIWYG styling.
+  #}
   <div class="node__content">
-    {{ content }}
+    {{ include('kingly_minimal:text', {
+      content: content
+    }, with_context=false) }}
   </div>
 
 </article>

--- a/templates/content/node.html.twig
+++ b/templates/content/node.html.twig
@@ -5,7 +5,8 @@
  *
  * This template now acts as a "dispatcher" based on the view mode.
  * - If the view mode is 'teaser', it includes the 'node-teaser' SDC.
- * - For all other view modes (e.g., 'full'), it renders the full node markup.
+ * - For all other view modes (e.g., 'full'), it renders the full node markup,
+ *   now using the `Image` and `Text` components for consistency.
  *
  * @see template_preprocess_node()
  * @see kingly_minimal/components/node-teaser/node-teaser.twig
@@ -56,7 +57,11 @@
 
     {% if display_submitted %}
       <footer class="node__meta">
-        {{ author_picture }}
+        {# Use the Image component for the author's picture. #}
+        {{ include('kingly_minimal:image', {
+          render_array: author_picture,
+          attributes: { class: ['user-picture'] }
+        }, with_context=false) }}
         <div{{ author_attributes.addClass('node__submitted') }}>
           {% trans %}Submitted by {{ author_name }} on {{ date }}{% endtrans %}
           {{ metadata }}
@@ -65,7 +70,10 @@
     {% endif %}
 
     <div{{ content_attributes.addClass('node__content') }}>
-      {{ content }}
+      {# Use the Text component to render the main content body. #}
+      {{ include('kingly_minimal:text', {
+        content: content
+      }, with_context=false) }}
     </div>
 
   </article>


### PR DESCRIPTION
Refactors existing templates and components to utilize the new `Image` and `Text` SDCs, promoting code reuse and consistency.

- Enhances the `Image` component to accept a `render_array` prop, allowing it to wrap pre-rendered Drupal images like `author_picture`.
- Updates `node-teaser.twig` and `node.html.twig` to delegate the rendering of author pictures and main content to the `Image` and `Text` components, respectively.
- Modifies the `footer-company-info` component to use the `Text` component for its description, enabling consistent styling for simple rich text.