### PR TITLE
fix(footer): Correct selectors for all embedded components

### DIFF
--- a/components/footer-company-info/footer-company-info.scss
+++ b/components/footer-company-info/footer-company-info.scss
@@ -5,7 +5,8 @@
 // The title styles have been moved to the footer-widget component.
 // -----------------------------------------------------------------------------
 
-[data-component-id='kingly_minimal:footer-company-info'] {
+// Use the component's own class as the primary selector.
+.footer-company-info {
   // Target the description paragraph.
   // Note: The `.prose` class from the Text component will handle the
   // base paragraph styling. We add this class for any specific overrides

--- a/components/footer-contact/footer-contact.scss
+++ b/components/footer-contact/footer-contact.scss
@@ -5,7 +5,8 @@
 // The title styles have been moved to the footer-widget component.
 // -----------------------------------------------------------------------------
 
-[data-component-id='kingly_minimal:footer-contact'] {
+// Use the component's own class as the primary selector.
+.footer-contact {
   // Style the <ul> element.
   .footer-contact__list {
     list-style: none;


### PR DESCRIPTION
Fixes a systemic issue where styles were not being applied to any component that embeds the `footer-widget`.

When a component is embedded, the SDC module applies the `data-component-id` of the parent component. This caused selectors based on the child component's ID to fail.

The stylesheets for `footer-link-list`, `footer-contact`, and `footer-company-info` have all been updated to use their unique BEM class as the primary selector, ensuring all component-specific styles are now correctly applied.