### PR TITLE
feat(pager): Add new Pager Single Directory Component

### DIFF
--- a/components/pager/pager.component.yml
+++ b/components/pager/pager.component.yml
@@ -1,0 +1,32 @@
+# kingly_minimal/components/pager/pager.component.yml
+name: 'Pager'
+status: stable
+description: 'Renders a styled pagination control for navigating through lists of content.'
+
+props:
+  type: object
+  properties:
+    # The list of pager items (first, previous, pages, next, last)
+    # provided by Drupal's pager service.
+    items:
+      type: object
+      title: 'Pager Items'
+      description: 'The structured list of pager links and text.'
+      default: {}
+    # The ID for the accessible heading, linking the nav to its label.
+    heading_id:
+      type: string
+      title: 'Heading ID'
+      description: 'The HTML ID for the visually hidden h4 heading.'
+      default: 'pagination-heading'
+    # HTML attributes for the <nav> element.
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the root <nav> element.'
+
+# Define the component's CSS assets. The build process will create this file.
+library:
+  css:
+    component:
+      pager.css: {}

--- a/components/pager/pager.scss
+++ b/components/pager/pager.scss
@@ -1,0 +1,72 @@
+// components/pager/pager.scss
+
+// -----------------------------------------------------------------------------
+// Pager Component Styles
+// -----------------------------------------------------------------------------
+
+// Scope all styles to the pager component for complete encapsulation.
+[data-component-id='kingly_minimal:pager'] {
+
+  // The <ul> element that wraps all pager items.
+  .pager__items {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--spacing-xs);
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+
+  // The link element within each pager item. This is our primary target for styling.
+  .pager__link {
+    // WCAG 2.5.5 (AAA): Ensure a minimum target size of 44x44px.
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    padding: var(--spacing-sm);
+
+    // Typography & Appearance
+    color: var(--color-primary);
+    text-decoration: none;
+    font-weight: 500;
+    border-radius: var(--border-radius);
+    transition: background-color 0.15s ease-in-out, color 0.15s ease-in-out;
+
+    // Hover & Focus States
+    &:hover {
+      background-color: var(--color-light-gray);
+      text-decoration: none;
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--color-primary);
+      outline-offset: 2px;
+    }
+  }
+
+  // Styles for the active pager item.
+  .pager__item.is-active {
+    .pager__link {
+      background-color: var(--color-primary);
+      color: var(--color-background);
+      font-weight: 700;
+      // Prevent hover effect on the active item.
+      &:hover {
+        background-color: var(--color-primary);
+      }
+    }
+  }
+
+  // The non-interactive ellipsis item.
+  .pager__item--ellipsis {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 44px;
+    color: var(--color-text);
+  }
+}

--- a/components/pager/pager.twig
+++ b/components/pager/pager.twig
@@ -1,0 +1,90 @@
+{#
+/**
+ * @file
+ * Component template for a pager.
+ *
+ * This template renders a pager with links for first, previous, next, last,
+ * and numbered pages. It is designed to be fully accessible.
+ *
+ * @see kingly_minimal/components/pager/pager.component.yml
+ *
+ * @props
+ * - items: A structured list of pager links.
+ * - heading_id: The HTML ID for the visually hidden h4 heading.
+ * - attributes: A Drupal attributes object for the root <nav> element.
+ */
+#}
+{% if items %}
+  <nav{{ attributes.addClass('pager').setAttribute('role', 'navigation').setAttribute('aria-labelledby', heading_id) }}>
+    <h4 id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</h4>
+    <ul class="pager__items">
+      {# Print first item if we are not on the first page. #}
+      {% if items.first %}
+        <li class="pager__item pager__item--first">
+          <a href="{{ items.first.href }}" class="pager__link" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title', 'class') }}>
+            <span class="visually-hidden">{{ 'First page'|t }}</span>
+            <span aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+
+      {# Print previous item if we are not on the first page. #}
+      {% if items.previous %}
+        <li class="pager__item pager__item--previous">
+          <a href="{{ items.previous.href }}" class="pager__link" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel', 'class') }}>
+            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
+            <span aria-hidden="true">{{ items.previous.text|default('‹ Previous'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+
+      {# Add an ellipsis if there are further previous pages. #}
+      {% if items.pages['…'] is defined %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">…</li>
+      {% endif %}
+
+      {# Now generate the actual page piece. #}
+      {% for key, item in items.pages %}
+        {% if key is number %}
+          <li class="pager__item pager__item--number {{ items.current == key ? 'is-active' }}">
+            {% set link_attributes = item.attributes|without('href', 'title', 'class') %}
+            {% if items.current == key %}
+              {% set link_attributes = link_attributes.setAttribute('aria-current', 'page') %}
+            {% endif %}
+            <a href="{{ item.href }}" class="pager__link" title="{{ 'Go to page @key'|t({'@key': key}) }}"{{ link_attributes }}>
+              <span class="visually-hidden">
+                {{ items.current == key ? 'Current page'|t : 'Page'|t }}
+              </span>
+              {{- key -}}
+            </a>
+          </li>
+        {% endif %}
+      {% endfor %}
+
+      {# Add an ellipsis if there are further next pages. #}
+      {% if items.pages['…'] is defined %}
+        <li class="pager__item pager__item--ellipsis" role="presentation">…</li>
+      {% endif %}
+
+      {# Print next item if we are not on the last page. #}
+      {% if items.next %}
+        <li class="pager__item pager__item--next">
+          <a href="{{ items.next.href }}" class="pager__link" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel', 'class') }}>
+            <span class="visually-hidden">{{ 'Next page'|t }}</span>
+            <span aria-hidden="true">{{ items.next.text|default('Next ›'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+
+      {# Print last item if we are not on the last page. #}
+      {% if items.last %}
+        <li class="pager__item pager__item--last">
+          <a href="{{ items.last.href }}" class="pager__link" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title', 'class') }}>
+            <span class="visually-hidden">{{ 'Last page'|t }}</span>
+            <span aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
+          </a>
+        </li>
+      {% endif %}
+    </ul>
+  </nav>
+{% endif %}

--- a/templates/navigation/pager.html.twig
+++ b/templates/navigation/pager.html.twig
@@ -3,88 +3,15 @@
  * @file
  * Theme override to display a pager.
  *
- * Available variables:
- * - items: A list of pager items.
- *   - first: The "first" page link.
- *   - previous: The "previous" page link.
- *   - pages: A list of page numbers.
- *   - next: The "next" page link.
- *   - last: The "last" page link.
- * - attributes: HTML attributes for the nav element.
- * - heading_id: The non-HTML safe heading ID.
+ * This template now acts as a bridge to the 'pager' Single Directory Component.
+ * It passes the necessary variables from the theme system to the component,
+ * which now handles all markup and styling.
  *
- * @see template_preprocess_pager()
+ * @see kingly_minimal/components/pager/pager.twig
  */
 #}
-{% if items %}
-  <nav class="pager" role="navigation" aria-labelledby="{{ heading_id }}">
-    <h4 id="{{ heading_id }}" class="visually-hidden">{{ 'Pagination'|t }}</h4>
-    <ul class="pager__items js-pager__items">
-      {# Print first item if we are not on the first page. #}
-      {% if items.first %}
-        <li class="pager__item pager__item--first">
-          <a href="{{ items.first.href }}" title="{{ 'Go to first page'|t }}"{{ items.first.attributes|without('href', 'title') }}>
-            <span class="visually-hidden">{{ 'First page'|t }}</span>
-            <span aria-hidden="true">{{ items.first.text|default('« First'|t) }}</span>
-          </a>
-        </li>
-      {% endif %}
-      {# Print previous item if we are not on the first page. #}
-      {% if items.previous %}
-        <li class="pager__item pager__item--previous">
-          <a href="{{ items.previous.href }}" title="{{ 'Go to previous page'|t }}" rel="prev"{{ items.previous.attributes|without('href', 'title', 'rel') }}>
-            <span class="visually-hidden">{{ 'Previous page'|t }}</span>
-            <span aria-hidden="true">{{ items.previous.text|default('‹ Previous'|t) }}</span>
-          </a>
-        </li>
-      {% endif %}
-      {# Add an ellipsis if there are further previous pages. #}
-      {% if items.pages.ellipsis_previous %}
-        <li class="pager__item pager__item--ellipsis" role="presentation">…</li>
-      {% endif %}
-      {# Now generate the actual page piece. #}
-      {% for key, item in items.pages %}
-        <li class="pager__item{{ key == current ? ' pager__item--active is-active' : '' }}">
-          {% if key == current %}
-            {% set title = 'Current page'|t %}
-          {% else %}
-            {% set title = 'Go to page @key'|t({'@key': key}) %}
-          {% endif %}
-          {# WCAG AAA (2.4.8 Location): Add 'aria-current="page"' to the active link. #}
-          {% set link_attributes = item.attributes|without('href', 'title') %}
-          {% if key == current %}
-            {% set link_attributes = link_attributes.setAttribute('aria-current', 'page') %}
-          {% endif %}
-          <a href="{{ item.href }}" title="{{ title }}"{{ link_attributes }}>
-            <span class="visually-hidden">
-              {{ key == current ? 'Current page'|t : 'Page'|t }}
-            </span>
-            {{- key -}}
-          </a>
-        </li>
-      {% endfor %}
-      {# Add an ellipsis if there are further next pages. #}
-      {% if items.pages.ellipsis_next %}
-        <li class="pager__item pager__item--ellipsis" role="presentation">…</li>
-      {% endif %}
-      {# Print next item if we are not on the last page. #}
-      {% if items.next %}
-        <li class="pager__item pager__item--next">
-          <a href="{{ items.next.href }}" title="{{ 'Go to next page'|t }}" rel="next"{{ items.next.attributes|without('href', 'title', 'rel') }}>
-            <span class="visually-hidden">{{ 'Next page'|t }}</span>
-            <span aria-hidden="true">{{ items.next.text|default('Next ›'|t) }}</span>
-          </a>
-        </li>
-      {% endif %}
-      {# Print last item if we are not on the last page. #}
-      {% if items.last %}
-        <li class="pager__item pager__item--last">
-          <a href="{{ items.last.href }}" title="{{ 'Go to last page'|t }}"{{ items.last.attributes|without('href', 'title') }}>
-            <span class="visually-hidden">{{ 'Last page'|t }}</span>
-            <span aria-hidden="true">{{ items.last.text|default('Last »'|t) }}</span>
-          </a>
-        </li>
-      {% endif %}
-    </ul>
-  </nav>
-{% endif %}
+{{ include('kingly_minimal:pager', {
+  items: items,
+  heading_id: heading_id,
+  attributes: attributes,
+}, with_context = false) }}


### PR DESCRIPTION
This commit introduces a new Single Directory Component (SDC) for pagination, fully encapsulating its logic, markup, and styles.

The pager is a highly reusable UI element in Drupal that was previously handled by a theme hook template (`pager.html.twig`) without dedicated, encapsulated styles. This change creates a robust and maintainable `pager` component to ensure a consistent appearance across the entire site (e.g., Views, search results).

Key changes include:
- A `pager.component.yml` file defines a clear API with props for items, heading_id, and attributes.
- The `pager.twig` template provides accessible, semantic markup, including `aria-current` for the active page.
- A new `pager.scss` file delivers fully encapsulated styles with clear active/focus states and ensures all links meet WCAG AAA target size requirements.
- The original `templates/navigation/pager.html.twig` has been converted into a simple bridge that includes the new SDC, ensuring all Drupal-rendered pagers will use our component.