### PR TITLE
feat(forms): Add foundational Form Element SDC

### DIFF
--- a/components/form-element/form-element.component.yml
+++ b/components/form-element/form-element.component.yml
@@ -1,0 +1,55 @@
+# kingly_minimal/components/form-element/form-element.component.yml
+name: 'Form Element'
+status: stable
+description: 'A wrapper for a form field that provides consistent layout for its label, description, and error messages.'
+
+props:
+  type: object
+  properties:
+    label:
+      type: object # Render array
+      title: 'Label'
+      description: 'The renderable array for the form element label.'
+    label_display:
+      type: string
+      title: 'Label Display'
+      description: 'The display setting for the label (e.g., "before", "after", "invisible").'
+      default: 'before'
+    description:
+      type: object # Render array
+      title: 'Description'
+      description: 'A renderable array for the form element description.'
+    description_display:
+      type: string
+      title: 'Description Display'
+      description: 'The display setting for the description (e.g., "before", "after", "invisible").'
+      default: 'after'
+    errors:
+      type: object # Render array
+      title: 'Errors'
+      description: 'Any validation errors for this form element.'
+    prefix:
+      type: object # Render array
+      title: 'Prefix'
+      description: 'The form element prefix.'
+    suffix:
+      type: object # Render array
+      title: 'Suffix'
+      description: 'The form element suffix.'
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the wrapper element.'
+
+# A slot is a placeholder for child content. In this case, it will hold the
+# actual <input>, <select>, or <textarea> element.
+slots:
+  content:
+    title: 'Content'
+    description: 'The form element itself (e.g., the textfield, select list, etc.).'
+
+# Define the component's CSS assets.
+library:
+  css:
+    component:
+      form-element.css: {}

--- a/components/form-element/form-element.scss
+++ b/components/form-element/form-element.scss
@@ -1,0 +1,88 @@
+// components/form-element/form-element.scss
+
+// -----------------------------------------------------------------------------
+// Form Element Component Styles
+// -----------------------------------------------------------------------------
+
+// Scope all styles to the form-element component.
+[data-component-id='kingly_minimal:form-element'] {
+  // Use grid for a simple, robust layout.
+  display: grid;
+  gap: var(--spacing-xs);
+
+  // --- Label Styles ---
+  // The label styles are handled by Drupal Core's form-label.html.twig,
+  // which adds the .form-label class. We target it here.
+  .form-label {
+    font-weight: 600;
+  }
+
+  // --- Description Styles ---
+  .form-item__description {
+    font-size: var(--font-size-sm);
+    color: var(--color-text);
+  }
+
+  // --- Error Styles ---
+  .form-item__error-message {
+    color: var(--color-error-text);
+    font-weight: 600;
+    font-size: var(--font-size-sm);
+  }
+
+  // When the component's wrapper has the .form-item--error class (added by
+  // Drupal), we can style the label to match the error state.
+  &.form-item--error .form-label {
+    color: var(--color-error-text);
+  }
+
+  // --- Prefix/Suffix Styles ---
+  .form-item__prefix,
+  .form-item__suffix {
+    display: flex;
+    align-items: center;
+    padding: var(--spacing-sm) var(--spacing-md);
+    background-color: var(--color-light-gray);
+    border: var(--border-width) solid var(--color-border);
+    border-radius: var(--border-radius);
+    white-space: nowrap;
+  }
+
+  // A common pattern is to have a prefix attached to an input.
+  // We can use flexbox on the content wrapper to handle this.
+  &.form-item--prefix-attached,
+  &.form-item--suffix-attached {
+    .form-item__content {
+      display: flex;
+
+      // The input should grow to fill the available space.
+      > .form-text {
+        flex-grow: 1;
+      }
+
+      // Round the corners correctly when attached.
+      .form-item__prefix {
+        border-right: 0;
+        border-top-right-radius: 0;
+        border-bottom-right-radius: 0;
+      }
+      .form-item__suffix {
+        border-left: 0;
+        border-top-left-radius: 0;
+        border-bottom-left-radius: 0;
+      }
+      .form-text {
+        border-radius: 0;
+
+        &:first-child {
+          border-top-left-radius: var(--border-radius);
+          border-bottom-left-radius: var(--border-radius);
+        }
+        &:last-child {
+          border-top-right-radius: var(--border-radius);
+          border-bottom-right-radius: var(--border-radius);
+        }
+      }
+    }
+  }
+}

--- a/components/form-element/form-element.twig
+++ b/components/form-element/form-element.twig
@@ -1,0 +1,63 @@
+{#
+/**
+ * @file
+ * Component template for a form element wrapper.
+ *
+ * This component provides the standard structure for a form field, including
+ * the label, description, and error messages. The actual input control
+ * is injected into the 'content' slot.
+ *
+ * @see kingly_minimal/components/form-element/form-element.component.yml
+ *
+ * @props
+ * - label: The renderable array for the label.
+ * - label_display: The display setting for the label.
+ * - description: A renderable array for the description.
+ * - description_display: The display setting for the description.
+ * - errors: Any validation errors for this form element.
+ * - prefix: The form element prefix.
+ * - suffix: The form element suffix.
+ * - attributes: A Drupal attributes object for the wrapper.
+ *
+ * @slots
+ * - content: The form element itself (e.g., input, select).
+ */
+#}
+<div{{ attributes.addClass('form-item') }}>
+
+  {% if label and label_display == 'before' %}
+    {{ label }}
+  {% endif %}
+
+  {% if description and description_display == 'before' %}
+    {{ description }}
+  {% endif %}
+
+  {% if prefix %}
+    <span class="form-item__prefix">{{ prefix }}</span>
+  {% endif %}
+
+  {# The 'content' block is the placeholder for the actual form input. #}
+  <div class="form-item__content">
+    {% block content %}{% endblock %}
+  </div>
+
+  {% if suffix %}
+    <span class="form-item__suffix">{{ suffix }}</span>
+  {% endif %}
+
+  {% if label and label_display == 'after' %}
+    {{ label }}
+  {% endif %}
+
+  {% if errors %}
+    <div class="form-item__error-message">
+      {{ errors }}
+    </div>
+  {% endif %}
+
+  {% if description and description_display == 'after' %}
+    {{ description }}
+  {% endif %}
+
+</div>

--- a/templates/form/form-element.html.twig
+++ b/templates/form/form-element.html.twig
@@ -1,0 +1,52 @@
+{#
+/**
+ * @file
+ * Theme override for a form element.
+ *
+ * This template has been refactored to act as a bridge to the 'form-element'
+ * Single Directory Component. It uses Twig's `embed` tag to wrap the form
+ * field (`children`) with the component's structure, passing all necessary
+ * variables as props.
+ *
+ * @see kingly_minimal/components/form-element/form-element.twig
+ */
+#}
+{% set classes = [
+  'js-form-item',
+  'form-item-' ~ name|clean_class,
+  'js-form-type-' ~ type|clean_class,
+  'js-form-item-' ~ name|clean_class,
+  title_attributes.id ? 'form-item--id-' ~ title_attributes.id,
+  label_display == 'invisible' ? 'form-item--label-invisible',
+  disabled ? 'form-item--disabled',
+  errors ? 'form-item--error',
+  prefix ? 'form-item--prefix-attached',
+  suffix ? 'form-item--suffix-attached',
+] %}
+{% set description_classes = [
+  'form-item__description',
+  description_display == 'invisible' ? 'visually-hidden',
+] %}
+
+{% embed 'kingly_minimal:form-element' with {
+  label: label,
+  label_display: label_display,
+  description: description ? {
+    '#type': 'html_tag',
+    '#tag': 'div',
+    '#value': description.content,
+    '#attributes': description.attributes.addClass(description_classes),
+  },
+  description_display: description_display,
+  errors: errors,
+  prefix: prefix,
+  suffix: suffix,
+  attributes: attributes.addClass(classes),
+} %}
+
+  {% block content %}
+    {# The 'children' variable contains the actual <input>, <select>, etc. #}
+    {{ children }}
+  {% endblock %}
+
+{% endembed %}


### PR DESCRIPTION
This commit introduces a new `form-element` Single Directory Component, which serves as the standard wrapper for all form fields. This is a major architectural enhancement and the first step toward a fully component-based form system.

The `form-element` SDC encapsulates the logic and styling for a field's label, description, and error messages, ensuring a consistent look and feel for all forms across the site.

Key changes include:
- A `form-element.component.yml` file defines a robust API with props for labels, descriptions, errors, and a `content` slot for the input control.
- The `form-element.twig` template provides the semantic markup for the wrapper and its parts.
- A `form-element.scss` file delivers encapsulated styles for the wrapper layout, label, description, and error message typography.
- The core `templates/form/form-element.html.twig` template has been refactored to use `{% embed %}`. It now acts as a bridge, wrapping all Drupal form fields with our new component.