### PR TITLE
feat(card): Add new general-purpose Card SDC

### DIFF
--- a/components/card/card.component.yml
+++ b/components/card/card.component.yml
@@ -1,0 +1,44 @@
+# kingly_minimal/components/card/card.component.yml
+name: 'Card'
+status: stable
+description: 'A versatile component for displaying content in a card-like format, often used for summaries or promotions.'
+
+props:
+  type: object
+  properties:
+    # Image props, to be passed to the image component.
+    image:
+      type: object
+      title: 'Image'
+      description: 'An object of props for the `kingly_minimal:image` component (e.g., src, alt).'
+    # The main title of the card.
+    title:
+      type: string
+      title: 'Title'
+      description: 'The heading for the card.'
+    # An optional URL for the title.
+    url:
+      type: string
+      title: 'URL'
+      description: 'An optional URL to make the title a link.'
+    # Body content, to be passed to the text component.
+    body:
+      type: [string, object]
+      title: 'Body'
+      description: 'The main text content for the card. Can be a string or render array.'
+    # Button props, to be passed to the button component.
+    button:
+      type: object
+      title: 'Button'
+      description: 'An object of props for the `kingly_minimal:button` component (e.g., text, url).'
+    # HTML attributes for the wrapper element.
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the root element.'
+
+# Define the component's CSS assets.
+library:
+  css:
+    component:
+      card.css: {}

--- a/components/card/card.scss
+++ b/components/card/card.scss
@@ -1,0 +1,48 @@
+// components/card/card.scss
+
+// -----------------------------------------------------------------------------
+// Card Component Styles
+// -----------------------------------------------------------------------------
+
+// Scope all styles to the card component.
+[data-component-id='kingly_minimal:card'] {
+  // Use grid to structure the card's sections (image, content, actions).
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--border-radius);
+  background-color: var(--color-background);
+  box-shadow: var(--box-shadow);
+  overflow: hidden; // Ensures the image's corners are clipped by the border-radius.
+  height: 100%; // Make the card fill the height of its container.
+
+  // The main content area of the card.
+  .card__content {
+    padding: var(--spacing-md);
+    display: grid;
+    gap: var(--spacing-sm);
+  }
+
+  // The card's title.
+  .card__title {
+    font-family: var(--font-family-heading);
+    font-size: var(--font-size-lg);
+    line-height: var(--line-height-heading);
+    margin: 0;
+
+    .card__title-link {
+      text-decoration: none;
+      color: inherit;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  // The actions/footer area of the card.
+  .card__actions {
+    padding: var(--spacing-md);
+    margin-top: auto; // Push the actions to the bottom of the card.
+  }
+}

--- a/components/card/card.twig
+++ b/components/card/card.twig
@@ -1,0 +1,55 @@
+{#
+/**
+ * @file
+ * Component template for a card.
+ *
+ * This component assembles other SDCs to create a versatile card. It uses the
+ * image, text, and button components to render its content.
+ *
+ * @see kingly_minimal/components/card/card.component.yml
+ *
+ * @props
+ * - image: An object of props for the `kingly_minimal:image` component.
+ * - title: The heading for the card.
+ * - url: (Optional) A URL to make the title a link.
+ * - body: The main text content for the card.
+ * - button: An object of props for the `kingly_minimal:button` component.
+ * - attributes: A Drupal attributes object for the root element.
+ */
+#}
+<div{{ attributes.addClass('card') }}>
+
+  {% if image.src %}
+    <div class="card__image">
+      {# Delegate image rendering to the image component. #}
+      {{ include('kingly_minimal:image', image, with_context=false) }}
+    </div>
+  {% endif %}
+
+  <div class="card__content">
+    {% if title %}
+      <h3 class="card__title">
+        {% if url %}
+          <a href="{{ url }}" class="card__title-link">{{ title }}</a>
+        {% else %}
+          {{ title }}
+        {% endif %}
+      </h3>
+    {% endif %}
+
+    {% if body %}
+      <div class="card__body">
+        {# Delegate body rendering to the text component for consistent prose styling. #}
+        {{ include('kingly_minimal:text', { content: body }, with_context=false) }}
+      </div>
+    {% endif %}
+  </div>
+
+  {% if button.text %}
+    <div class="card__actions">
+      {# Delegate button rendering to the button component. #}
+      {{ include('kingly_minimal:button', button, with_context=false) }}
+    </div>
+  {% endif %}
+
+</div>

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,7 @@
       "Drupal\\kingly_minimal\\": "src/"
     }
   },
-  "require": {}
+  "require": {
+    "drupal/twig_tweak": "^3.4"
+  }
 }


### PR DESCRIPTION
This commit introduces a new, versatile `card` Single Directory Component.

The `card` component is a general-purpose tool for displaying content in a promotional or summary format. It is designed to be highly reusable and is not tied to a specific Drupal element, making it ideal for site builders.

Key changes:
- A `card.component.yml` file defines a flexible API for an optional image, title, body text, and call-to-action button.
- The `card.twig` template is a prime example of a compositional architecture, including the existing `image`, `text`, and `button` SDCs to build its structure.
- A new `card.scss` file provides the "shell" styling for the card, such as border, shadow, and internal layout.
- The `page.html.twig` template has been updated to include a multi-card demonstration as a fallback for the `content_bottom` region, serving as living documentation.