### PR TITLE
fix(theme): Add and document Twig Tweak dependency

### DIFF
--- a/kingly_minimal.info.yml
+++ b/kingly_minimal.info.yml
@@ -4,6 +4,11 @@ description: 'A minimal, modern base theme with a Vite-powered SDC architecture.
 core_version_requirement: ^10 || ^11
 base theme: stable9
 
+# Declare theme dependencies. This theme requires the Twig Tweak module to
+# provide the `drupal_image` function used in the `image` component.
+dependencies:
+  - twig_tweak:twig_tweak
+
 # Load the single global-styles library on all pages.
 # Component-specific assets are attached automatically by the SDC module.
 libraries:


### PR DESCRIPTION
This commit resolves a critical error caused by an undeclared dependency on the Twig Tweak module. The `image` component uses the `drupal_image()` function, which is provided by Twig Tweak and is not part of Drupal core.

This change formalizes the dependency at all necessary levels:
- **`kingly_minimal.info.yml`:** The `twig_tweak` module is now listed as a required dependency, preventing the theme from being enabled if the module is missing and thus avoiding a fatal error.