### PR TITLE
feat(search): Add new Search Result SDC

### DIFF
--- a/components/search-result/search-result.component.yml
+++ b/components/search-result/search-result.component.yml
@@ -1,0 +1,34 @@
+# kingly_minimal/components/search-result/search-result.component.yml
+name: 'Search Result'
+status: stable
+description: 'Renders a single search result item with a title, snippet, and metadata.'
+
+props:
+  type: object
+  properties:
+    url:
+      type: string
+      title: 'URL'
+      description: 'The URL of the search result.'
+    title:
+      type: string
+      title: 'Title'
+      description: 'The title of the search result.'
+    snippet:
+      type: object # Can be a render array
+      title: 'Snippet'
+      description: 'A snippet of the search result content.'
+    info:
+      type: object # Can be a render array
+      title: 'Info'
+      description: 'Additional information about the search result (e.g., author, date).'
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the root element.'
+
+# Define the component's CSS assets.
+library:
+  css:
+    component:
+      search-result.css: {}

--- a/components/search-result/search-result.scss
+++ b/components/search-result/search-result.scss
@@ -1,0 +1,41 @@
+// components/search-result/search-result.scss
+
+// -----------------------------------------------------------------------------
+// Search Result Component Styles
+// -----------------------------------------------------------------------------
+
+// Scope all styles to the search-result component.
+[data-component-id='kingly_minimal:search-result'] {
+  // Add a border to separate search results in a list.
+  padding-bottom: var(--spacing-lg);
+  margin-bottom: var(--spacing-lg);
+  border-bottom: var(--border-width) solid var(--color-border);
+
+  // The title of the search result.
+  .search-result__title {
+    font-size: var(--font-size-lg);
+    font-family: var(--font-family-heading);
+    margin-bottom: var(--spacing-xs);
+
+    a {
+      text-decoration: none;
+      color: var(--color-primary);
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+  }
+
+  // The metadata info (author, date, etc.).
+  .search-result__info {
+    font-size: var(--font-size-sm);
+    color: var(--color-text);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  // The text snippet from the result.
+  .search-result__snippet {
+    // Styling is inherited from the base line-height, which is sufficient.
+  }
+}

--- a/components/search-result/search-result.twig
+++ b/components/search-result/search-result.twig
@@ -1,0 +1,34 @@
+{#
+/**
+ * @file
+ * Component template for a single search result.
+ *
+ * @see kingly_minimal/components/search-result/search-result.component.yml
+ *
+ * @props
+ * - url: The URL of the search result.
+ * - title: The title of the search result.
+ * - snippet: A snippet of the search result content.
+ * - info: Additional information about the search result.
+ * - attributes: A Drupal attributes object for the root element.
+ */
+#}
+<article{{ attributes.addClass('search-result') }}>
+  {% if title %}
+    <h3 class="search-result__title">
+      <a href="{{ url }}">{{ title }}</a>
+    </h3>
+  {% endif %}
+
+  {% if info %}
+    <div class="search-result__info">
+      {{ info }}
+    </div>
+  {% endif %}
+
+  {% if snippet %}
+    <div class="search-result__snippet">
+      {{ snippet }}
+    </div>
+  {% endif %}
+</article>

--- a/templates/search/search-result.html.twig
+++ b/templates/search/search-result.html.twig
@@ -1,0 +1,19 @@
+{#
+/**
+ * @file
+ * Theme override for a single search result.
+ *
+ * This template now acts as a bridge to the 'search-result' Single Directory
+ * Component. It passes the necessary variables from the theme system to the
+ * component, which now handles all markup and styling.
+ *
+ * @see kingly_minimal/components/search-result/search-result.twig
+ */
+#}
+{{ include('kingly_minimal:search-result', {
+  url: url,
+  title: title,
+  snippet: snippet,
+  info: info,
+  attributes: attributes,
+}, with_context = false) }}


### PR DESCRIPTION
This commit introduces a new Single Directory Component (SDC) for displaying a single search result item, fully encapsulating its markup and styles.

Previously, search results were rendered by a theme hook template (`search-result.html.twig`) with no dedicated, encapsulated styles. This change creates a robust and maintainable `search-result` component to ensure a consistent and clean appearance on the search results page.

Key changes include:
- A `search-result.component.yml` file defines a clear API with props for the URL, title, snippet, and info.
- The `search-result.twig` template provides semantic markup for the result item.
- A new `search-result.scss` file delivers encapsulated styles for consistent typography and spacing.
- The original `templates/search/search-result.html.twig` has been refactored into a simple bridge that includes the new SDC, ensuring all search results will now use our component.