### PR TITLE
refactor(menu): Decouple menu and footer-menu components

### DIFF
--- a/components/footer-menu/footer-menu.component.yml
+++ b/components/footer-menu/footer-menu.component.yml
@@ -1,6 +1,6 @@
 name: Footer Menu
 status: stable
-description: Renders a menu, styled for the footer region.
+description: Renders a menu, styled for the footer region, by wrapping the canonical `menu` component and applying contextual style overrides.
 props:
   type: object
   properties:
@@ -16,3 +16,10 @@ props:
       type: object
       title: Attributes
       description: HTML attributes for the wrapper.
+
+# Define the component's CSS assets. This file contains only the overrides
+# for the generic menu component.
+library:
+  css:
+    component:
+      footer-menu.css: {}

--- a/components/footer-menu/footer-menu.scss
+++ b/components/footer-menu/footer-menu.scss
@@ -1,31 +1,44 @@
-// kingly_minimal/components/footer-menu/footer-menu.scss
+// components/footer-menu/footer-menu.scss
 
 // -----------------------------------------------------------------------------
 // Footer Menu Component Styles
+//
+// This file provides context-specific overrides for the generic `menu` component
+// when it is used inside the `footer-menu` component.
 // -----------------------------------------------------------------------------
 
-// Scope all styles to the footer-menu component.
+// The data-component-id is on the <nav> wrapper. We target the .menu
+// class of the `menu` component within it.
 [data-component-id='kingly_minimal:footer-menu'] {
 
-  // Target the menu list within the component.
+  // Override the layout of the generic menu.
   .menu {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    // The menu in the footer's bottom bar should be inline and wrap.
-    display: flex;
+    // The footer menu is always horizontal and wrapped, regardless of breakpoint.
+    flex-direction: row;
     flex-wrap: wrap;
     gap: var(--spacing-md);
   }
 
-  // Target the menu links within the component.
+  // Override the link styles for the footer context.
   .menu__link {
-    text-decoration: none;
-    color: var(--color-text);
+    // Reset styles from the generic menu component.
+    padding: 0;
+    min-height: auto;
+    border-radius: 0;
+    font-weight: normal;
     font-size: var(--font-size-sm);
 
-    &:hover {
+    // Provide footer-specific interaction styles.
+    &:hover,
+    &:focus {
+      background-color: transparent;
       text-decoration: underline;
+    }
+
+    &.is-active {
+      font-weight: normal;
+      text-decoration: underline;
+      color: var(--color-text); // Reset active color from primary.
     }
   }
 }

--- a/components/footer-menu/footer-menu.twig
+++ b/components/footer-menu/footer-menu.twig
@@ -3,21 +3,12 @@
  * @file
  * Theme override for the footer menu block.
  *
- * This component template provides a semantic <nav> element for the footer menu
- * and improves accessibility by using the block's label as an ARIA label.
+ * This component acts as a wrapper. It renders the semantic <nav> element
+ * and then includes the `kingly_minimal:menu` component to render the menu
+ * tree itself. The specific styling for the footer context is applied by
+ * this component's own stylesheet.
  *
- * It is loaded via a theme hook suggestion in kingly_minimal.theme, targeting
- * the 'footer' menu specifically.
- *
- * Available variables:
- * - plugin_id: The ID of the block implementation.
- * - label: The configured label of the block if visible.
- * - configuration: A list of the block's configuration values.
- * - content: The content of the block (the menu tree).
- * - attributes: HTML attributes for the containing element.
- *
- * @see template_preprocess_block()
- * @see kingly_minimal_preprocess_block()
+ * @see kingly_minimal/components/footer-menu/footer-menu.component.yml
  */
 #}
 {% set heading_id = attributes.id ~ '-label' %}
@@ -45,7 +36,15 @@ Conditionally set the accessible name for the navigation.
     <h2{{ title_attributes.addClass('visually-hidden') }} id="{{ heading_id }}">{{ label }}</h2>
   {% endif %}
   {{ title_suffix }}
-  {% block content %}
-    {{ content }}
-  {% endblock %}
+
+  {#
+  We include our generic `menu` SDC. This component's `footer-menu.scss` will
+  automatically apply the necessary contextual style overrides.
+  #}
+  {% if content['#items'] %}
+    {{ include('kingly_minimal:menu', {
+      items: content['#items'],
+      attributes: content['#attributes'],
+    }, with_context = false) }}
+  {% endif %}
 </nav>

--- a/components/menu/menu.component.yml
+++ b/components/menu/menu.component.yml
@@ -16,6 +16,10 @@ props:
       title: 'Menu Level'
       description: 'The current depth of the menu, used for styling.'
       default: 0
+    modifier:
+      type: string
+      title: 'Modifier'
+      description: 'An optional BEM modifier class for the menu (e.g., "footer").'
     attributes:
       type: object
       title: 'Attributes'

--- a/components/menu/menu.scss
+++ b/components/menu/menu.scss
@@ -3,30 +3,24 @@
 @use '../../scss/base/mixins' as *;
 
 // -----------------------------------------------------------------------------
-// Menu Component Styles
-// The root element of this component IS the <ul> menu list.
+// Generic Menu Component Styles
+// This component is now unaware of specific contexts like 'footer'.
 // -----------------------------------------------------------------------------
 [data-component-id='kingly_minimal:menu'] {
-  // Apply list-reset styles directly to the component's root element.
   list-style: none;
   padding: 0;
   margin: 0;
   display: flex;
-
-  // --- Mobile Layout (Default): Vertical List ---
   flex-direction: column;
   gap: 0;
 
-  // --- Tablet and Desktop Layout: Horizontal List ---
+  // By default, this is the main menu, so it becomes horizontal on desktop.
   @include media-query(md) {
     flex-direction: row;
     flex-wrap: wrap;
     gap: var(--spacing-md);
   }
 
-  // ---------------------------------------------------------------------------
-  // Menu Link Styles (Descendants of the root)
-  // ---------------------------------------------------------------------------
   .menu__link {
     display: inline-flex;
     align-items: center;
@@ -36,6 +30,7 @@
     border-radius: var(--border-radius);
     font-weight: 500;
     transition: background-color 0.15s ease-in-out;
+    color: var(--color-text);
 
     &:hover,
     &:focus {
@@ -48,6 +43,7 @@
       color: var(--color-primary);
     }
 
+    // Mobile-specific styles for the default menu.
     @include media-query(md, 'max') {
       padding-inline: 0;
       border-radius: 0;
@@ -55,7 +51,6 @@
     }
   }
 
-  // Hide sub-menus by default.
   .menu__sub-menu {
     display: none;
   }


### PR DESCRIPTION
This commit refactors the relationship between the `menu` and `footer-menu` components to achieve a purer, more encapsulated architecture.

Previously, the generic `menu` component was modified to contain styles for a `.menu--footer` variant, making it aware of its consumers.

This has been corrected by:
- Removing all footer-specific logic and styles from the `menu` SDC, making it truly generic.
- Re-introducing a `footer-menu.scss` file that contains only the CSS overrides needed to style the generic `menu` component for the footer context.
- The `footer-menu` component now fully encapsulates its own styling variations, rather than relying on the `menu` component to provide them.