### PR TITLE
feat(forms): Add Checkboxes wrapper SDC for grid layouts

### DIFF
--- a/components/checkboxes/checkboxes.component.yml
+++ b/components/checkboxes/checkboxes.component.yml
@@ -1,0 +1,23 @@
+# kingly_minimal/components/checkboxes/checkboxes.component.yml
+name: 'Checkboxes'
+status: stable
+description: 'A layout container for a group of checkbox items, typically arranging them in a grid.'
+
+props:
+  type: object
+  properties:
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the root wrapper element.'
+
+slots:
+  content:
+    title: 'Content'
+    description: 'The rendered list of individual checkbox items.'
+
+# Define the component's CSS assets.
+library:
+  css:
+    component:
+      checkboxes.css: {}

--- a/components/checkboxes/checkboxes.scss
+++ b/components/checkboxes/checkboxes.scss
@@ -1,0 +1,26 @@
+// components/checkboxes/checkboxes.scss
+
+// -----------------------------------------------------------------------------
+// Checkboxes Wrapper Component Styles
+// -----------------------------------------------------------------------------
+
+// Scope all styles to the checkboxes component.
+[data-component-id='kingly_minimal:checkboxes'] {
+  // Use CSS Grid for a robust, responsive layout.
+  display: grid;
+  gap: var(--spacing-sm);
+
+  // Define the columns. This will create as many 200px columns as can fit,
+  // and then distribute the remaining space equally.
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+
+  // The direct children of this container are the .form-item divs for each
+  // individual checkbox, which are rendered by our form-element SDC.
+  // We can add specific styles for them in this context if needed.
+  .form-item--type-checkbox {
+    // Example: Add a border around each item in the grid.
+    // border: 1px solid var(--color-border);
+    // padding: var(--spacing-sm);
+    // border-radius: var(--border-radius);
+  }
+}

--- a/components/checkboxes/checkboxes.twig
+++ b/components/checkboxes/checkboxes.twig
@@ -1,0 +1,20 @@
+{#
+/**
+ * @file
+ * Component template for a checkboxes wrapper.
+ *
+ * This component provides a container for a group of checkbox items.
+ * Its primary purpose is to apply layout styles (like a grid) to the group.
+ *
+ * @see kingly_minimal/components/checkboxes/checkboxes.component.yml
+ *
+ * @props
+ * - attributes: A Drupal attributes object for the root wrapper element.
+ *
+ * @slots
+ * - content: The rendered list of individual checkbox items.
+ */
+#}
+<div{{ attributes.addClass('checkboxes') }}>
+  {% block content %}{% endblock %}
+</div>

--- a/templates/form/form-element--type-checkboxes.html.twig
+++ b/templates/form/form-element--type-checkboxes.html.twig
@@ -1,65 +1,51 @@
 {#
 /**
  * @file
- * Theme override for a form element.
+ * Theme override for a checkboxes form element.
  *
- * This is a copy of the base form-element.html.twig, intended to be used for
- * a group of checkboxes. For this template to be used by Drupal, you must add
- * a theme hook suggestion in your kingly_minimal.theme file.
+ * This template demonstrates nested composition of SDCs. It embeds the main
+ * `form-element` SDC to get the standard label and wrapper. Inside that, it
+ * embeds the `checkboxes` SDC to provide a grid layout for the children.
  *
- * Available variables:
- * - attributes: HTML attributes for the containing element.
- * - errors: (optional) Any errors for this form element, may not be set.
- * - prefix: (optional) The form element prefix, may not be set.
- * - suffix: (optional) The form element suffix, may not be set.
- * - required: A boolean indicating whether the given form element is required.
- * - type: The type of the element.
- * - name: The name of the element.
- * - label: A renderable array for the form element label.
- * - label_display: The display settings for the label.
- * - description: A renderable array for the form element description.
- * - children: The rendered form element.
- *
- * @see template_preprocess_form_element()
+ * @see kingly_minimal/components/form-element/form-element.twig
+ * @see kingly_minimal/components/checkboxes/checkboxes.twig
  */
 #}
-{% set classes = [
+{%
+  set classes = [
   'js-form-item',
-  'form-item',
-  'js-form-type-' ~ type|clean_class,
   'form-item-' ~ name|clean_class,
+  'js-form-type-' ~ type|clean_class,
   'js-form-item-' ~ name|clean_class,
   title_attributes.id ? 'form-item--id-' ~ title_attributes.id,
-  not title_is_different ? 'form-item--no-label',
-  label_display == 'after' ? 'form-item--label-after',
   label_display == 'invisible' ? 'form-item--label-invisible',
   disabled ? 'form-item--disabled',
   errors ? 'form-item--error',
-] %}
-{% set description_classes = [
-  'description',
-  description_display == 'invisible' ? 'visually-hidden',
-] %}
-<div{{ attributes.addClass(classes) }}>
-  {% if prefix is not empty %}
-    <span class="field-prefix">{{ prefix }}</span>
-  {% endif %}
-  {% if label_display in ['before', 'invisible'] %}
-    {{ label }}
-  {% endif %}
-  {{ children }}
-  {% if suffix is not empty %}
-    <span class="field-suffix">{{ suffix }}</span>
-  {% endif %}
-  {% if label_display == 'after' %}
-    {{ label }}
-  {% endif %}
-  {% if errors %}
-    <div class="form-item--error-message">
-      <strong>{{ errors }}</strong>
-    </div>
-  {% endif %}
-  {% if description %}
-    <div{{ description_attributes.addClass(description_classes) }}>{{ description }}</div>
-  {% endif %}
-</div>
+]
+%}
+
+{# Embed the main form-element wrapper first. #}
+{% embed 'kingly_minimal:form-element' with {
+  label: label,
+  label_display: label_display,
+  errors: errors,
+  attributes: attributes.addClass(classes),
+} %}
+
+  {# Inside the 'content' slot of the form-element... #}
+  {% block content %}
+
+    {# ...embed the checkboxes wrapper component. #}
+    {% embed 'kingly_minimal:checkboxes' %}
+
+      {# Inside the 'content' slot of the checkboxes wrapper... #}
+      {% block content %}
+        {# ...finally, render the actual checkbox items from Drupal. #}
+        {{ children }}
+      {% endblock %}
+
+    {% endembed %}
+
+  {% endblock %}
+
+{% endembed %}


### PR DESCRIPTION
This commit introduces a new `checkboxes` Single Directory Component (SDC) to provide a dedicated layout container for groups of checkbox items.

Previously, a list of checkboxes would render as a simple vertical list with no easy way to apply columnar or grid styling. This new component solves that by wrapping the list in a container styled with CSS Grid.

Key changes include:
- A new `checkboxes` component has been created to manage the layout of checkbox groups.
- The `checkboxes.scss` file applies a responsive CSS Grid, arranging items neatly into columns.
- The `templates/form/form-element--type-checkboxes.html.twig` bridge template has been refactored to use nested composition, embedding the new `checkboxes` SDC inside the main `form-element` SDC.