### PR TITLE
feat(paragraphs): Add Button paragraph recipe and SDC

### DIFF
--- a/components/button/button.component.yml
+++ b/components/button/button.component.yml
@@ -1,41 +1,48 @@
 # components/button/button.component.yml
 name: 'Button'
 status: stable
-description: 'Renders a versatile and accessible button element.'
+description: 'Renders a versatile and accessible button element with optional style variations and icons.'
 
 props:
   type: object
   properties:
-    # The text content to be displayed inside the button.
     text:
       type: string
       title: 'Text'
       description: 'The label displayed on the button.'
       default: ''
-    # The URL the button links to. If provided, the component renders as an <a> tag.
-    # If omitted, it renders as a <button> tag.
     url:
       type: string
       title: 'URL'
       description: 'The destination URL. Renders the component as a link.'
       default: ''
-    # The HTML element to use for the button. Defaults to 'button'.
-    # Can be set to 'a' for links styled as buttons.
     element:
       type: string
       title: 'HTML Element'
       description: 'The HTML tag to use for the button (e.g., "button" or "a").'
       default: 'button'
-    # Additional HTML attributes for the button/link element.
+    style:
+      type: string
+      title: Style
+      description: 'The visual style of the button.'
+      default: 'primary'
+      enum:
+        - 'primary'
+        - 'secondary'
+    icon_before:
+      type: string
+      title: 'Icon Before'
+      description: 'The machine name of an icon from the `kingly_minimal:icon` component to display before the text.'
+    icon_after:
+      type: string
+      title: 'Icon After'
+      description: 'The machine name of an icon from the `kingly_minimal:icon` component to display after the text.'
     attributes:
       type: object
       title: 'Attributes'
       description: 'A Drupal attributes object for adding classes, IDs, etc.'
 
-# Defines the assets that this component needs to render correctly.
-# The SDC module will automatically discover and attach these.
 library:
   css:
     component:
-      # Points to the compiled CSS file within this component's directory.
       button.css: {}

--- a/components/button/button.scss
+++ b/components/button/button.scss
@@ -6,7 +6,8 @@
 
 // Scope all styles to the button component to ensure encapsulation.
 // The data-component-id is automatically added by the SDC module.
-[data-component-id='kingly_minimal:button'] {
+// We target the `.button` class added by the Twig template for styling.
+.button {
   // Reset default browser appearance for consistency.
   -webkit-appearance: none;
   appearance: none;
@@ -15,8 +16,9 @@
   display: inline-flex; // Allows for easy alignment of text/icons.
   align-items: center;
   justify-content: center;
+  gap: var(--spacing-sm); // Space between icon and text.
   padding: var(--spacing-sm) var(--spacing-md);
-  border: var(--border-width) solid transparent; // Prevents layout shift on hover.
+  border: var(--border-width-medium) solid transparent; // Use thicker border for secondary style.
   border-radius: var(--border-radius);
 
   // Typography
@@ -28,23 +30,13 @@
   text-decoration: none;
   white-space: nowrap; // Keep button text on a single line.
 
-  // Colors & Background
-  background-color: var(--color-primary);
-  color: var(--color-background);
-
   // Interaction
   cursor: pointer;
-  transition: background-color var(--transition-duration) var(--transition-timing-function),
-  border-color var(--transition-duration) var(--transition-timing-function);
+  transition: background-color var(--transition-duration-fast) var(--transition-timing-function),
+  border-color var(--transition-duration-fast) var(--transition-timing-function),
+  color var(--transition-duration-fast) var(--transition-timing-function);
 
   // States: Hover, Focus, Disabled
-  &:hover {
-    background-color: var(--color-primary-hover);
-    color: var(--color-background);
-    text-decoration: none;
-  }
-
-  // Remove the default outline. We'll use focus-visible for a better one.
   &:focus {
     outline: none;
   }
@@ -61,5 +53,44 @@
     opacity: 0.65;
     cursor: not-allowed;
     pointer-events: none; // Prevent clicks on disabled elements.
+  }
+
+  // --- Style Variants ---
+
+  // Primary Style (Default)
+  &, // Apply to .button without a modifier class
+  &--primary {
+    background-color: var(--color-primary);
+    color: var(--color-background);
+    border-color: var(--color-primary);
+
+    &:hover {
+      background-color: var(--color-primary-hover);
+      border-color: var(--color-primary-hover);
+      color: var(--color-background);
+      text-decoration: none;
+    }
+  }
+
+  // Secondary Style (Outline)
+  &--secondary {
+    background-color: transparent;
+    color: var(--color-primary);
+    border-color: var(--color-primary);
+
+    &:hover {
+      background-color: var(--color-primary);
+      color: var(--color-background);
+      text-decoration: none;
+    }
+  }
+
+  // --- Icon Styles ---
+  .button__icon {
+    // The icon SDC will handle the fill color via `currentColor`.
+    .icon > svg {
+      width: var(--size-icon-sm);
+      height: var(--size-icon-sm);
+    }
   }
 }

--- a/components/button/button.twig
+++ b/components/button/button.twig
@@ -4,8 +4,7 @@
  * Component template for a button.
  *
  * This component renders a button or a link styled as a button. It dynamically
- * chooses the correct HTML tag based on the provided props, ensuring semantic
-* and accessible output.
+ * chooses the correct HTML tag and can now include leading and trailing icons.
  *
  * @see kingly_minimal/components/button/button.component.yml
  *
@@ -13,16 +12,40 @@
  * - text: The label for the button.
  * - url: (Optional) The URL for the link. If present, an <a> tag is rendered.
  * - element: (Optional) The HTML tag to use, defaults to 'button' if no URL.
+ * - style: (Optional) The style variant ('primary', 'secondary').
+ * - icon_before: (Optional) Machine name of an icon to render before the text.
+ * - icon_after: (Optional) Machine name of an icon to render after the text.
  * - attributes: A Drupal attributes object for adding custom classes, etc.
  */
 #}
 {% set tag = url ? 'a' : element|default('button') %}
+{% set base_class = 'button' %}
+{% set classes = [
+  base_class,
+  style ? base_class ~ '--' ~ style,
+] %}
 
 <{{ tag }}
   {% if tag == 'a' and url %}
     href="{{ url }}"
   {% endif %}
-  {{ attributes }}
+  {{ attributes.addClass(classes) }}
 >
-{{- text -}}
+{% if icon_before %}
+  {{ include('kingly_minimal:icon', {
+    name: icon_before,
+    attributes: create_attribute().addClass(base_class ~ '__icon', base_class ~ '__icon--before'),
+  }, with_context=false) }}
+{% endif %}
+
+  {% if text %}
+    <span class="{{ base_class }}__text">{{ text }}</span>
+  {% endif %}
+
+  {% if icon_after %}
+    {{ include('kingly_minimal:icon', {
+      name: icon_after,
+      attributes: create_attribute().addClass(base_class ~ '__icon', base_class ~ '__icon--after'),
+    }, with_context=false) }}
+  {% endif %}
 </{{ tag }}>

--- a/templates/paragraphs/paragraph--kingly-paragraph-button.html.twig
+++ b/templates/paragraphs/paragraph--kingly-paragraph-button.html.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Theme override for the Button paragraph type.
+ *
+ * This template acts as a bridge, mapping the paragraph's raw field values
+ * directly to the props of the 'kingly_minimal:button' SDC. This data-driven
+ * approach provides the cleanest possible markup.
+ *
+ * @see kingly_minimal/components/button/button.twig
+ */
+#}
+{% set link_item = paragraph.field_button_link|first %}
+
+{%
+  set button_props = {
+  'attributes': attributes.addClass('paragraph--type--button'),
+  'url': link_item ? link_item.url,
+  'text': link_item ? link_item.title : '',
+  'style': paragraph.field_button_style.value,
+  'icon_before': paragraph.field_button_icon_before.value,
+  'icon_after': paragraph.field_button_icon_after.value,
+}
+%}
+
+{{ include('kingly_minimal:button', button_props, with_context=false) }}


### PR DESCRIPTION
Creates a new paragraph type for adding styled buttons to content. This feature encapsulates all configuration in a portable Drupal recipe.

- Defines the `kingly_paragraph_button` recipe with a new paragraph type and fields for a link, style, and optional before/after icons.
- Updates the `kingly_minimal:button` Single Directory Component to accept `style`, `icon_before`, and `icon_after` props.
- The SDC's Twig and SCSS were updated to render the icons and apply style variants (`.button--secondary`).
- Implements the "SDC Bridge" pattern in the `paragraph--kingly-paragraph-button.html.twig` template, mapping raw field data directly to component props for clean, controlled markup.
- Uses predefined lists for styles and icons to enforce design system consistency.