### PR TITLE
feat(paragraph): Add Quote paragraph type and SDC

### DIFF
--- a/components/quote/quote.component.yml
+++ b/components/quote/quote.component.yml
@@ -1,0 +1,26 @@
+$schema: https://git.drupalcode.org/project/drupal/-/raw/HEAD/core/assets/schemas/v1/metadata.schema.json
+name: 'Quote'
+status: stable
+description: 'Renders a blockquote with an optional attribution. Ideal for testimonials or highlighting text.'
+
+props:
+  type: object
+  properties:
+    quote_text:
+      type: [string, object] # Can be a string or a render array
+      title: 'Quote Text'
+      description: 'The main content of the quote.'
+      required: true
+    attribution:
+      type: string
+      title: 'Attribution'
+      description: '(Optional) The source of the quote, such as a person or publication.'
+    attributes:
+      type: object
+      title: 'Attributes'
+      description: 'A Drupal attributes object for the root element.'
+
+library:
+  css:
+    component:
+      quote.css: {}

--- a/components/quote/quote.scss
+++ b/components/quote/quote.scss
@@ -1,0 +1,41 @@
+// kingly_minimal/components/quote/quote.scss
+
+// -----------------------------------------------------------------------------
+// Quote Component Styles
+// -----------------------------------------------------------------------------
+
+// Scope all styles to the component for encapsulation.
+[data-component-id='kingly_minimal:quote'] {
+  // The root element is the <blockquote>
+  display: block; // Ensure block-level behavior.
+  margin: 0; // Reset any user-agent margins.
+  padding-left: var(--spacing-lg);
+  border-left: var(--border-width-thick) solid var(--color-primary);
+
+  // The main text of the quote.
+  .quote__text {
+    font-size: var(--font-size-h4);
+    font-style: italic;
+    line-height: var(--line-height-heading);
+    color: var(--color-text);
+
+    // Remove margins from the <p> tag that comes from the rich text field.
+    p {
+      margin: 0;
+    }
+  }
+
+  // The attribution/source of the quote.
+  .quote__attribution {
+    margin-top: var(--spacing-md);
+    font-size: var(--font-size-base);
+    font-style: normal; // Contrast with the italic quote.
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-text);
+
+    // Add a decorative em dash before the attribution text.
+    &::before {
+      content: '— ';
+    }
+  }
+}

--- a/components/quote/quote.twig
+++ b/components/quote/quote.twig
@@ -1,0 +1,26 @@
+{#
+/**
+ * @file
+ * Component template for a blockquote.
+ *
+ * This component renders the quote text and an optional attribution within a
+ * semantic <blockquote> element.
+ *
+ * @see kingly_minimal/components/quote/quote.component.yml
+ *
+ * @props
+ * - quote_text: The main content of the quote.
+ * - attribution: (Optional) The source of the quote.
+ * - attributes: A Drupal attributes object for the root element.
+ */
+#}
+<blockquote{{ attributes.addClass('quote') }}>
+  <div class="quote__text">
+    {{- quote_text -}}
+  </div>
+  {% if attribution %}
+    <footer class="quote__attribution">
+      {{- attribution -}}
+    </footer>
+  {% endif %}
+</blockquote>

--- a/templates/paragraphs/paragraph--kingly-paragraph-quote.html.twig
+++ b/templates/paragraphs/paragraph--kingly-paragraph-quote.html.twig
@@ -1,0 +1,22 @@
+{#
+/**
+ * @file
+ * Theme override for the Kingly Quote paragraph type.
+ *
+ * This template acts as a bridge, mapping the paragraph's field data
+ * directly to the props of the 'kingly_minimal:quote' SDC. This data-driven
+ * approach bypasses the Drupal field rendering system for the cleanest possible
+ * markup.
+ *
+ * @see kingly_minimal/components/quote/quote.twig
+ */
+#}
+{%
+  set quote_props = {
+  'attributes': attributes.addClass('paragraph--type--quote'),
+  'quote_text': content.field_quote_text,
+  'attribution': paragraph.field_quote_attribution.value,
+}
+%}
+
+{{ include('kingly_minimal:quote', quote_props, with_context=false) }}


### PR DESCRIPTION
Creates a new recipe for a "Kingly Quote" paragraph type. This includes the necessary paragraph type, fields for quote text and attribution, and default form/view displays.

Adds a corresponding "quote" Single Directory Component to the kingly_minimal theme to provide semantic markup and styling. A new paragraph template bridges the Drupal entity data to the component's props, ensuring clean, controllable output.

Updates the main `kingly` recipe to include the new quote paragraph.