### PR TITLE
feat(accordion): Animate opening and closing of items

### DIFF
--- a/components/accordion-item/accordion-item.scss
+++ b/components/accordion-item/accordion-item.scss
@@ -30,28 +30,52 @@
     }
   }
 
-  // The content wrapper div.
+  // The content wrapper div, configured for animation.
   .accordion-item__content {
+    display: grid;
+    // Set the initial (closed) state.
+    grid-template-rows: 0fr;
+    // Define the transition for the grid rows.
+    transition: grid-template-rows var(--transition-duration-slow) ease-in-out;
+  }
+
+  // The inner wrapper is required for the animation to work correctly.
+  .accordion-item__content-inner {
+    // The padding is moved here so it animates with the content.
     padding: var(--spacing-md);
-    border-top: var(--border-width-thin) solid var(--color-border);
+    // This allows the element's height to shrink to zero.
+    overflow: hidden;
+    min-height: 0;
   }
 
   // The custom icon wrapper.
   .accordion-item__icon {
     display: inline-flex;
-    transition: transform var(--transition-duration-medium) ease-in-out;
-    // WCAG: Ensure motion is disabled for users who prefer it.
-    @media (prefers-reduced-motion: reduce) {
-      transition: none;
-    }
+    transition: transform var(--transition-duration-slow) ease-in-out;
   }
 
   // State change when the <details> element is open.
   &[open] {
     > .accordion-item__header {
+      // Add a border between the header and content when open.
+      border-bottom: var(--border-width-thin) solid var(--color-border);
+
       .accordion-item__icon {
         transform: rotate(180deg);
       }
+    }
+
+    // When open, transition the grid rows to reveal the content.
+    .accordion-item__content {
+      grid-template-rows: 1fr;
+    }
+  }
+
+  // WCAG: Respect user preference for reduced motion.
+  @media (prefers-reduced-motion: reduce) {
+    .accordion-item__icon,
+    .accordion-item__content {
+      transition: none;
     }
   }
 }

--- a/components/accordion-item/accordion-item.twig
+++ b/components/accordion-item/accordion-item.twig
@@ -4,7 +4,8 @@
  * Component template for a single accordion item.
  *
  * This component now renders the `heading` and `content` from props instead
- * of slots for a cleaner data flow from Drupal.
+ * of slots for a cleaner data flow from Drupal. An inner wrapper has been
+ * added to the content area to facilitate smooth CSS animations.
  *
  * @see kingly_minimal/components/accordion-item/accordion-item.component.yml
  *
@@ -23,9 +24,11 @@
     </span>
   </summary>
   <div class="accordion-item__content">
-    {# Delegate content rendering to the text component for consistent prose styling. #}
-    {{ include('kingly_minimal:text', {
-      content: content
-    }, with_context = false) }}
+    {# This inner wrapper is essential for the grid-template-rows animation. #}
+    <div class="accordion-item__content-inner">
+      {{ include('kingly_minimal:text', {
+        content: content
+      }, with_context = false) }}
+    </div>
   </div>
 </details>


### PR DESCRIPTION
Implements a smooth slide animation for the accordion-item component using a modern CSS Grid technique.

- Updates the accordion-item.twig template to include a necessary inner wrapper for the animation.
- Modifies the SCSS to transition the `grid-template-rows` property from 0fr to 1fr, creating a natural slide effect that correctly handles variable content heights.
- Improves visual polish by moving the separator border to the header when an item is open.
- Respects `prefers-reduced-motion` to disable animations for accessibility.