### PR TITLE
feat(slideshow): Correct DOM structure and fix styles

### DIFF
--- a/components/slideshow/slideshow.js
+++ b/components/slideshow/slideshow.js
@@ -6,7 +6,7 @@
  * responsive configuration from data attributes, and initialize a Splide.js
  * instance for each one.
  */
-(function (Drupal, once) {
+(function (Drupal, once, Splide) {
   'use strict';
 
   /**
@@ -35,6 +35,9 @@
         const splide = new Splide(slideshow, {
           // A standard slider that does not loop.
           type: 'slide',
+          // Explicitly set the slide direction to left-to-right. This is a
+          // safeguard against potential issues and ensures perPage works as expected.
+          direction: 'ltr',
           // Set the base (mobile) number of slides per page.
           perPage: perPageMobile,
           // Use the theme's variable for consistent spacing.
@@ -63,4 +66,4 @@
     },
   };
 
-})(Drupal, once);
+})(Drupal, once, Splide);

--- a/components/slideshow/slideshow.scss
+++ b/components/slideshow/slideshow.scss
@@ -22,6 +22,12 @@
     margin: 0; // Reset any default heading margins.
   }
 
+  &__navigation {
+    // Ensure the arrow buttons are aligned horizontally with a gap.
+    display: flex;
+    gap: var(--spacing-sm);
+  }
+
   // --- Splide.js Theme Overrides ---
   // We target the Splide classes within our component to apply our theme.
   .splide {
@@ -81,5 +87,20 @@
     // This ensures that child items (our cards) stretch to the full height
     // of the track, creating a uniform appearance.
     align-items: stretch;
+  }
+}
+
+// --- Dark Mode Overrides ---
+html[data-theme="dark"] {
+  .slideshow {
+    .splide__arrow {
+      // Improve visibility of disabled arrows in dark mode.
+      &:disabled {
+        // Use a semi-transparent version of the dark theme's text color.
+        color: rgba(255, 255, 255, 0.4);
+        border-color: rgba(255, 255, 255, 0.2);
+        opacity: 1; // Override the light-mode opacity rule.
+      }
+    }
   }
 }

--- a/templates/field/field--paragraph--field-slideshow-slides--kingly-paragraph-slideshow.html.twig
+++ b/templates/field/field--paragraph--field-slideshow-slides--kingly-paragraph-slideshow.html.twig
@@ -1,0 +1,17 @@
+{#
+/**
+ * @file
+ * Theme override for the 'field_slideshow_slides' field.
+ *
+ * This template removes all default field wrappers (e.g., .field__items,
+ * .field__item) for the slideshow items. This is critical because the Splide.js
+ * library requires the slide `<li>` elements to be direct children of the
+ * `<ul>` container. By rendering only the item content, we ensure the correct
+ * DOM structure.
+ *
+ * @see template_preprocess_field()
+ */
+#}
+{% for item in items %}
+  {{ item.content }}
+{% endfor %}


### PR DESCRIPTION
Resolves issues with the slideshow component where slides were stacking vertically and `perPage` settings were not being applied.

The primary issue was caused by Drupal's default field wrappers being inserted between the Splide `<ul>` and `<li>` elements, which is invalid markup for the library.

This commit introduces a specific Twig template override (`field--...--field-slideshow-slides.html.twig`) to remove these wrappers, ensuring the correct DOM structure.

Additionally, the following fixes have been implemented:
- SCSS has been updated to correctly position the navigation arrows in the header.
- Added dark mode-specific styles to ensure disabled arrows have sufficient contrast and are visible.
- The Splide JavaScript initialization is made more robust by explicitly setting `direction: 'ltr'` and properly importing the Splide object.